### PR TITLE
Pin background-geolocaiton version at 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": "~15.3.1",
     "react-native": "0.37.0",
-    "react-native-background-geolocation": "^2.3.0",
+    "react-native-background-geolocation": "2.3.0",
     "react-native-device-info": "0.9.3",
     "react-native-drawer": "^2.2.6",
     "react-native-mapbox-gl": "^5.1.0",


### PR DESCRIPTION
Demo app is not ready for react-native `0.40.0` until `react-native-mapbox-gl` provides an update for `0.40.0`.  Pin BackgroundGeolocation at the pre `0.40.0` version.