### PR TITLE
Fixes warning for deprecated icon property

### DIFF
--- a/src/advanced/HomeView.js
+++ b/src/advanced/HomeView.js
@@ -616,7 +616,7 @@ export default class HomeView extends Component<{}> {
           active={this.state.isMainMenuOpen}
           backgroundTappable={true}
           onPress={this.onClickMainMenu.bind(this)}
-          icon={<Icon name="ios-add" size={25}/>}
+          renderIcon={() => <Icon name="ios-add" size={25}/>}
           verticalOrientation="down"
           buttonColor="rgba(254,221,30,1)"
           buttonTextStyle={{color: "#000"}}


### PR DESCRIPTION
The react-native-action-button component has deprecated their `icon` property, replacing it with `renderIcon` (see [Configuration](https://github.com/mastermoo/react-native-action-button#configuration)).  This fixes the usage of the deprecated property to remove the warnings that appear in the simulator.