### PR TITLE
fixing ReactNativeFlipper android package name

### DIFF
--- a/android/app/src/debug/java/com/bggeolocation/ReactNativeFlipper.java
+++ b/android/app/src/debug/java/com/bggeolocation/ReactNativeFlipper.java
@@ -4,7 +4,7 @@
  * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
  * directory of this source tree.
  */
-package com.bggeolocation;
+package com.transistorsoft.backgroundgeolocation.react;
 
 import android.content.Context;
 import com.facebook.flipper.android.AndroidFlipperClient;


### PR DESCRIPTION
Flipper connects to device but not application because of wrong package name